### PR TITLE
Modify createRecord to use Location header

### DIFF
--- a/app/adapters/fedora-jsonld.js
+++ b/app/adapters/fedora-jsonld.js
@@ -94,14 +94,13 @@ export default DS.Adapter.extend({
     return this._ajax(url, "POST", {
       data: JSON.stringify(data),
       headers: {'Content-Type': 'application/ld+json; charset=utf-8'},
-      dataFilter: function(resp) {
-        // Fedora returns assigned URI as plain text.
-        // Return JSON-LD object for serializer.normalizeResponse.
+    }).then((resp, status, xhr) => {
+      // Return JSON-LD object with @id for serializer.normalizeResponse.
 
-        data['@id'] = resp.trim();
+      let id = xhr.getResponseHeader('Location');
+      data['@id'] = id;
 
-        return data;
-      }
+      return data;
     });
   },
 

--- a/tests/unit/adapters/fedora-jsonld-test.js
+++ b/tests/unit/adapters/fedora-jsonld-test.js
@@ -109,12 +109,12 @@ module('Unit | Adapter | fedora jsonld', function(hooks) {
     server = new Pretender(function() {
       this.post('http://localhost/data/barns', function() {
         assert.step('post barn');
-        return [200, { "Content-Type": "plain/text" }, barn_id];
+        return [200, { "Content-Type": "plain/text", "Location": barn_id }, barn_id];
       });
 
       this.post('http://localhost/data/kine', function() {
         assert.step('post cow');
-        return [200, { "Content-Type": "plain/text" }, cow_id];
+        return [200, { "Content-Type": "plain/text", "Location": cow_id }, cow_id];
       });
 
       this.put('http://localhost/data/kine/123', function() {
@@ -184,7 +184,7 @@ module('Unit | Adapter | fedora jsonld', function(hooks) {
     server = new Pretender(function() {
       this.post('http://localhost/data/kine', function() {
         assert.step('post');
-        return [200, { "Content-Type": "plain/text" }, id];
+        return [200, { "Content-Type": "plain/text", "Location": id }, id];
       });
     });
 


### PR DESCRIPTION
Instead of using the POST response createRecord now uses the location header to find the URI of a created resource.

Closes #2.