### PR TITLE
Use Json Merge Patch on updateRecord.

### DIFF
--- a/.esindex.json
+++ b/.esindex.json
@@ -7,6 +7,7 @@
         "@type": {"type": "keyword"},
         "name": {"type": "text"},
         "weight": {"type": "integer"},
+        "healthy": {"type": "boolean"},
         "birthDate": {"type": "date"},
         "milkVolume": {"type": "float"},
         "colors": {"type": "keyword"},

--- a/README.md
+++ b/README.md
@@ -115,13 +115,18 @@ The adapter requires @id and @type be used. It does not check the context for po
 
 The only context processing is expansion of compact IRIs for property names and type values.
 This expansion only happens if the context is included. The default behavior is for Fedora to
-rather verbosely include context.
+rather verbosely include context. The adapter works best if Fedora is modified to return clean
+compact JSON-LD based on the model context.
 
 The ember attribute type object (basic Javasript object) is not supported. The Fedora single
 subject restriction would make support a bit awkward. Note that JSON arrays of simple types
 are suppoted with set.
 
 Ember attribute transforms are not supported.
+
+# Requirements on Fedora
+
+Fedora must support Json Merge Patch.
 
 ## Searching
 

--- a/app/adapters/fedora-jsonld.js
+++ b/app/adapters/fedora-jsonld.js
@@ -118,8 +118,9 @@ export default DS.Adapter.extend({
 
   /**
     Called by the store when an existing record is saved
-    via the `save` method on a model record instance. The Fedora container resprenting
-    the record is replaced with a PUT.
+    via the `save` method on a model record instance. The Fedora container representing
+    the record is updated with a PATCH which relies on Fedora supporting
+    JSON Merge Patch.
 
     TODO Handle concurrency, if-modified
 
@@ -134,9 +135,9 @@ export default DS.Adapter.extend({
     let serializer = store.serializerFor(type.modelName);
     let data = serializer.serialize(snapshot);
 
-    return this._ajax(url, 'PUT', {
+    return this._ajax(url, 'PATCH', {
       headers: {
-        'Content-Type': 'application/ld+json; charset=utf-8',
+        'Content-Type': 'application/merge-patch+json; charset=utf-8',
         'Prefer': JSON_LD_PREFER_HEADER
       },
       data: JSON.stringify(data)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT
+    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1
     container_name: fcrepo    
     env_file: .env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-1
+    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-2
     container_name: fcrepo    
     env_file: .env
     environment:

--- a/tests/integration/fedora-jsonld-test.js
+++ b/tests/integration/fedora-jsonld-test.js
@@ -27,7 +27,7 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
   // Small delays help indexer sync with Fedora and Elasticsearch
 
   hooks.beforeEach(function() {
-    return delay(4000);
+    return delay(5000);
   });
 
   hooks.beforeEach(function() {
@@ -37,7 +37,7 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
   });
 
   hooks.beforeEach(function() {
-    return delay(4000);
+    return delay(5000);
   });
 
   hooks.beforeEach(function() {
@@ -92,10 +92,7 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
       barn1_id = barn1_record.get('id');
       barn2_id = barn2_record.get('id');
 
-      // Clear the cache to make sure we test the retrieved records.
-      store.unloadAll();
-
-      return store.findAll('barn');
+      return store.findAll('barn', {reload: true});
     }).then(result => {
       assert.step('findAll');
 
@@ -150,10 +147,7 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
         let id = record.get('id');
         assert.ok(id);
 
-        // Clear the cache to make sure we test the retrieved record.
-        store.unloadAll();
-
-        return store.findRecord('cow', id);
+        return store.findRecord('cow', id, {reload: true});
       }).then(cow => {
           assert.step('findRecord');
 
@@ -170,12 +164,12 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
     });
   });
 
-  // Show that JSON Merge is working.
+  // Show that updateRecord is working.
   integrationTest('update a cow', function(assert) {
     let store = this.owner.lookup('service:store');
 
     let name = 'dumbo';
-    let milkVolume = 10;
+    let weight = 10;
     let healthy = true;
     let record;
     let id;
@@ -193,9 +187,7 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
       id = record.get('id');
       assert.ok(id);
 
-      // Clear the cache to make sure we test the retrieved record.
-      store.unloadAll();
-      return store.findRecord('cow', id);
+      return store.findRecord('cow', id, {reload: true});
     }).then(cow => {
       assert.step('findRecord');
 
@@ -203,23 +195,21 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
       assert.equal(cow.get('name'), name);
 
       // Add properties
-      cow.set('milkVolume', milkVolume);
+      cow.set('weight', weight);
       cow.set('healthy', healthy);
 
       return cow.save();
     }).then(() => {
       assert.step('save');
 
-      // Clear the cache to make sure we test the retrieved record.
-      store.unloadAll();
-      return store.findRecord('cow', id);
+      return store.findRecord('cow', id, {reload: true});
     }).then(cow => {
       assert.step('findRecord');
       assert.verifySteps(['save', 'findRecord', 'save', 'findRecord'])
 
       assert.ok(cow);
       assert.equal(cow.get('name'), name);
-      assert.equal(cow.get('milkVolume'), milkVolume);
+      assert.equal(cow.get('weight'), weight);
       assert.equal(cow.get('healthy'), healthy);
     });
   });
@@ -247,9 +237,6 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
       id = barn.get('id');
       assert.ok(id);
 
-      // Clear the cache to make sure we test the retrieved record.
-      //store.unloadAll();
-
       return barn.destroyRecord();
     }).then(() => {
       assert.step('delete');
@@ -257,7 +244,7 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
       // TODO Must clear store or findRecord causes internal ember data error
       store.unloadAll();
 
-      return store.findRecord('barn', id).catch(() => assert.step('get fail'));
+      return store.findRecord('barn', id, {reload: true}).catch(() => assert.step('get fail'));
     });
 
     return result.then(() => {
@@ -309,10 +296,7 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
         barn_id = barn_record.get('id');
         assert.ok(barn_id);
 
-        // Clear the cache to make sure we test retrieved records.
-        store.unloadAll();
-
-        return store.findRecord('cow', cow_id);
+        return store.findRecord('cow', cow_id, {reload: true});
       }).then(cow => {
           assert.step('cow findRecord');
 
@@ -320,7 +304,7 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
           assert.equal(cow.get('weight'), cow_data.weight);
 
           // Empty set not expected to be persisted.
-          assert.notOk(cow.get('colors'));
+          assert.deepEqual(cow.get('colors'), []);
 
           assert.equal(cow.get('birthDate').toISOString(), cow_data.birthDate.toISOString());
 
@@ -338,10 +322,7 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
 
           return cow.save().then(() => barn.save());
         }).then(() => {
-            // Clear the cache to make sure we test retrieved records.
-            store.unloadAll();
-
-            return store.findRecord('cow', cow_id);
+            return store.findRecord('cow', cow_id, {reload: true});
         }).then(cow => {
           assert.equal(cow.get('barn.id'), barn_id);
 

--- a/tests/integration/fedora-jsonld-test.js
+++ b/tests/integration/fedora-jsonld-test.js
@@ -170,6 +170,60 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
     });
   });
 
+  // Show that JSON Merge is working.
+  integrationTest('update a cow', function(assert) {
+    let store = this.owner.lookup('service:store');
+
+    let name = 'dumbo';
+    let milkVolume = 10;
+    let healthy = true;
+    let record;
+    let id;
+
+    return run(() => {
+      record = store.createRecord('cow', {name: name});
+      assert.ok(record);
+
+      assert.equal(record.get('name'), name);
+
+      return record.save();
+    }).then(() => {
+      assert.step('save');
+
+      id = record.get('id');
+      assert.ok(id);
+
+      // Clear the cache to make sure we test the retrieved record.
+      store.unloadAll();
+      return store.findRecord('cow', id);
+    }).then(cow => {
+      assert.step('findRecord');
+
+      assert.ok(cow);
+      assert.equal(cow.get('name'), name);
+
+      // Add properties
+      cow.set('milkVolume', milkVolume);
+      cow.set('healthy', healthy);
+
+      return cow.save();
+    }).then(() => {
+      assert.step('save');
+
+      // Clear the cache to make sure we test the retrieved record.
+      store.unloadAll();
+      return store.findRecord('cow', id);
+    }).then(cow => {
+      assert.step('findRecord');
+      assert.verifySteps(['save', 'findRecord', 'save', 'findRecord'])
+
+      assert.ok(cow);
+      assert.equal(cow.get('name'), name);
+      assert.equal(cow.get('milkVolume'), milkVolume);
+      assert.equal(cow.get('healthy'), healthy);
+    });
+  });
+
   integrationTest('delete a barn', function(assert) {
     let store = this.owner.lookup('service:store');
 

--- a/tests/unit/adapters/fedora-jsonld-test.js
+++ b/tests/unit/adapters/fedora-jsonld-test.js
@@ -118,12 +118,12 @@ module('Unit | Adapter | fedora jsonld', function(hooks) {
         return [200, { "Content-Type": "plain/text", "Location": cow_id }, cow_id];
       });
 
-      this.put('http://localhost/data/kine/123', function() {
+      this.patch('http://localhost/data/kine/123', function() {
         assert.step('put cow');
         return [200, { "Content-Type": "plain/text" }, ''];
       });
 
-      this.put('http://localhost/data/barns/a/b/21', function() {
+      this.patch('http://localhost/data/barns/a/b/21', function() {
         assert.step('put barn');
         return [200, { "Content-Type": "plain/text" }, ''];
       });

--- a/tests/unit/serializers/fedora-jsonld-test.js
+++ b/tests/unit/serializers/fedora-jsonld-test.js
@@ -31,7 +31,9 @@ module('Unit | Serializer | fedora-jsonld', function(hooks) {
       weight: data.weight,
       healthy: data.healthy,
       milkVolume: data.milkVolume,
-      birthDate: data.birthDate.toISOString()
+      birthDate: data.birthDate.toISOString(),
+      colors: null,
+      barn: null
     };
 
     let result = record.serialize();
@@ -48,7 +50,7 @@ module('Unit | Serializer | fedora-jsonld', function(hooks) {
       colors: ['teal', 'purple'],
       healthy: false,
       milkVolume: 1.5,
-      birthDate: new Date(Date.UTC(96, 11, 1, 0, 0, 0))
+      birthDate: new Date(Date.UTC(96, 11, 1, 0, 0, 0)),
     };
 
     let record = run(() => store.createRecord('cow', data));
@@ -62,7 +64,8 @@ module('Unit | Serializer | fedora-jsonld', function(hooks) {
       colors: data.colors,
       healthy: data.healthy,
       milkVolume: data.milkVolume,
-      birthDate: data.birthDate.toISOString()
+      birthDate: data.birthDate.toISOString(),
+      barn: null
     };
 
     let result = record.serialize();
@@ -77,7 +80,14 @@ module('Unit | Serializer | fedora-jsonld', function(hooks) {
     let expected = {
       '@context': ENV.test.context,
       '@id': '',
-      '@type': 'Cow'
+      '@type': 'Cow',
+      name: null,
+      weight: null,
+      healthy: null,
+      birthDate: null,
+      milkVolume: null,
+      colors: null,
+      barn: null
     };
 
     let result = record.serialize();
@@ -107,7 +117,11 @@ module('Unit | Serializer | fedora-jsonld', function(hooks) {
       '@type': 'Cow',
       name: cow_data.name,
       weight: cow_data.weight,
-      birthDate: cow_data.birthDate.toISOString()
+      birthDate: cow_data.birthDate.toISOString(),
+      healthy: null,
+      milkVolume: null,
+      colors: null,
+      barn: null
     };
 
     let cow_result = cow_record.serialize();
@@ -116,7 +130,9 @@ module('Unit | Serializer | fedora-jsonld', function(hooks) {
       '@context': ENV.test.context,
       '@id': '',
       '@type': 'Barn',
-      name: barn_data.name
+      name: barn_data.name,
+      cows: null,
+      colors: null
     };
 
     let barn_result = barn_record.serialize();


### PR DESCRIPTION
Persisting a modified object will now do a Json Merge Patch to Fedora. From the Ember perspective there should be no difference in behavior. This matches the support added to Fedora in fcrepo 4.7.5-2.0-SNAPSHOT-2. If you wish to run with pass-ember, note that you must update the fcrepo image version in docker-compose.yml.

Closes #8.

 - [x] Use Json Merge Patch on updateRecord.
 - [x] Integration test against Fedora Json Merge support
 - [x] Documentation update