### PR TITLE
Modify adapter to ignore attributes which start with an underscore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ in the context as terms. By default an attribute or relationships name maps dire
 must be used consistently in all models. Some terms in the context require a type set, some do not. Whether or not an optional type is specified will
 oddly influence compaction, but will not affect the adapter.
 
+If an attribute starts with an `_`, it will be ignored by the adapter and not persisted to Fedora.
+
 The set type is an extension provided to handle arrays of simple types like strings, numbers, and booleans.
 The adapter will not preserve the order of a set attribute when an object is persisted. The adapter will
 not persist an empty set.

--- a/app/serializers/fedora-jsonld.js
+++ b/app/serializers/fedora-jsonld.js
@@ -218,14 +218,20 @@ export default DS.Serializer.extend({
       let value = snapshot.attr(key);
       let name = this.serializeKey(type, key);
 
-      if (value != undefined && value != null) {
-        jsonld[name] = this._serialize_attr(value, attribute.type);
-      } else {
-        jsonld[name] = null;
+      if (key.charAt(0) !== '_') {
+        if (value != undefined && value != null) {
+          jsonld[name] = this._serialize_attr(value, attribute.type);
+        } else {
+          jsonld[name] = null;
+        }
       }
     });
 
     snapshot.eachRelationship((key, relationship) => {
+      if (key.charAt(0) === '_') {
+        return;
+      }
+
       let name = this.serializeKey(type, key);
 
       if (relationship.kind === 'belongsTo') {
@@ -245,9 +251,9 @@ export default DS.Serializer.extend({
           jsonld[name] = null;
         }
       }
-     });
+    });
 
-     return jsonld;
+    return jsonld;
   },
 
  /**

--- a/tests/dummy/app/models/cow.js
+++ b/tests/dummy/app/models/cow.js
@@ -7,5 +7,7 @@ export default DS.Model.extend({
   birthDate: DS.attr('date'),
   milkVolume: DS.attr('number'),
   colors: DS.attr('set'),
-  barn: DS.belongsTo('barn')
+  barn: DS.belongsTo('barn'),
+  _moo: DS.attr('string'),
+  _has_bff: DS.belongsTo('cow', { inverse: null })
 });

--- a/tests/unit/serializers/fedora-jsonld-test.js
+++ b/tests/unit/serializers/fedora-jsonld-test.js
@@ -41,6 +41,35 @@ module('Unit | Serializer | fedora-jsonld', function(hooks) {
     assert.deepEqual(result, expected);
   });
 
+  test('it serializes cow with hidden attribute', function(assert) {
+    let store = this.owner.lookup('service:store');
+
+    let data = {
+      name: 'wilbur',
+      weight: 800,
+      _moo: 'excellent'
+    };
+
+    let record = run(() => store.createRecord('cow', data));
+
+    let expected = {
+      '@context': ENV.test.context,
+      '@id': '',
+      '@type': 'Cow',
+      name: data.name,
+      weight: data.weight,
+      healthy: null,
+      milkVolume: null,
+      birthDate: null,
+      colors: null,
+      barn: null
+    };
+
+    let result = record.serialize();
+
+    assert.deepEqual(result, expected);
+  });
+
   test('it serializes cow with array property', function(assert) {
     let store = this.owner.lookup('service:store');
 
@@ -145,6 +174,9 @@ module('Unit | Serializer | fedora-jsonld', function(hooks) {
     run(() => {
       cow_record.set('id', 'cow:34');
       barn_record.set('id', 'barn:10');
+
+      // Also try setting a hidden relationship which should be ignored
+      cow_record.set('_has_bff', cow_record);
 
       cow_record.set('barn', barn_record);
       barn_record.get('cows').pushObject(cow_record);


### PR DESCRIPTION
Builds off of https://github.com/OA-PASS/ember-fedora-adapter/pull/14
