### PR TITLE
Update sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Example JSON-LD context:
 
 ```
 
-Some required types are set, some are not.
+Some types are set, some are not.
 
 ## Ember data structure in Fedora
 
@@ -145,12 +145,13 @@ The query argument can be the form: clause or
       query: clause,
       from: number,
       size: number,
+      sort: sort_request,
       info: object_ref
     }
     ```
 
 If the query argument has a 'query' key, the clause is taken
-to be the value of that key. If 'from' or 'size' keys are present in the
+to be the value of that key. If 'from', 'size', or 'sort' keys are present in the
 query argument, they are used to modify what results are returned. If the
 'info' key is present, its value is an object reference upon which the 'total'
 key is set to the total number of matching results. Note that if the query

--- a/app/adapters/fedora-jsonld.js
+++ b/app/adapters/fedora-jsonld.js
@@ -237,6 +237,10 @@ export default DS.Adapter.extend({
       }
     };
 
+    result._source = {
+      excludes: "*_suggest"
+    };
+
     return result;
   },
 

--- a/app/adapters/fedora-jsonld.js
+++ b/app/adapters/fedora-jsonld.js
@@ -214,20 +214,17 @@ export default DS.Adapter.extend({
   },
 
   // Create an elasticsearch query that restricts the given query to the given type.
-  // Add size and from from options if presents
+  // Add size, sort, and from from options if presents
   _create_elasticsearch_query(query, jsonld_type) {
     let result = {};
     let clause = Object.assign({}, query);
 
-    if ('size' in clause) {
-      result.size = query.size;
-      delete clause.size;
-    }
-
-    if ('from' in clause) {
-      result.from = query.from;
-      delete clause.from;
-    }
+    ['size', 'from', 'sort'].forEach(key => {
+        if (key in clause) {
+          result[key] = query[key];
+          delete clause[key];
+        }
+    });
 
     if ('query' in clause) {
       clause = clause.query;

--- a/tests/integration/fedora-jsonld-test.js
+++ b/tests/integration/fedora-jsonld-test.js
@@ -384,8 +384,8 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
     }).then(() => assert.verifySteps(['save', 'wait', 'query']));
   });
 
-  // Persist three barns and test from, size, and info when doing a query
-  integrationTest('query with from and limit', function(assert) {
+  // Persist three barns and test from, size, sort, and info when doing a query
+  integrationTest('query with sort, from. and limit', function(assert) {
     let store = this.owner.lookup('service:store');
 
     let barn1_data = {
@@ -430,7 +430,8 @@ module('Integration | Adapter | fedora jsonld', function(hooks) {
       assert.ok(result);
       assert.equal(result.get('length'), 2);
 
-      return store.query('barn', {term: {colors : 'green'}, from: 1, size: 2});
+      return store.query('barn', {term: {colors : 'green'}, sort: {colors: {order: 'asc', mode: 'max'}},
+        from: 1, size: 2});
     }).then(result => {
       assert.ok(result);
       assert.equal(result.get('length'), 2);


### PR DESCRIPTION
Support `sort` option in Store.query. See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html for the syntax.

Modify Store.query to filter out *_suggest fields in source documents. This has no effect beyond reducing the amount of data transferred.

Closes #16 
Closes #12 