### PR TITLE
Possible (ugly) work-around for expired Shib sessions

### DIFF
--- a/app/serializers/fedora-jsonld.js
+++ b/app/serializers/fedora-jsonld.js
@@ -57,6 +57,19 @@ export default DS.Serializer.extend({
     //console.log('normalizeResponse for ' + requestType);
     //console.log(payload);
 
+    if (typeof payload === 'string') {
+      /*
+       * In the case of an expired session cookie, Shib seems to respond with a 302 status to 
+       * automatically redirect to the login page, which the JS is happy to do. Can't seem to 
+       * intercept this before it redirects, so the ultimate response captured here can be the 
+       * HTML SAML response page.
+       *
+       * In the case that 'string' payload is found, assume this redirection has occured and 
+       * force the page to reload to either show the shib login page, or refresh the session
+       * token, or whatever shib decides to do.
+       */
+      window.location.reload(true);
+    }
     // Extract dataURI prefix if contained by inline @context
     let context = payload['@context'];
     let data_prefix = null;


### PR DESCRIPTION
## Manual testing using `pass-ember`
_(Kind of optional)_ If you don't do this modification, I think the default session timeout is one hour
* You can modify the `sp` container from `pass-docker` so that the session expires quickly, retag and build the new image.
* Modify `.docker/shib/docker-compose.yml` to point to the `sp` image you just created
-----

You need to pull this code into the `pass-ember/package.json` so it can be used in the `ember` container

* **Original**: `"ember-fedora-adapter": "git+https://github.com/OA-PASS/ember-fedora-adapter.git#master",`
* **Modified**: `"ember-fedora-adapter": "git+https://github.com/jabrah/ember-fedora-adapter.git#fix/expired-shib-session",`

-----
* Run `docker-compose up` from `pass-ember/.docker/shib`
* Login as some known user, then try to navigate to the Grants page
* The page should reload.