### PR TITLE
Expanded patch to reload page when Shibboleth times out

### DIFF
--- a/app/adapters/fedora-jsonld.js
+++ b/app/adapters/fedora-jsonld.js
@@ -313,13 +313,26 @@ export default DS.Adapter.extend({
     return this._ajax(url, 'POST', {
       data: JSON.stringify(data),
       headers: {'Content-Type': 'application/json; charset=utf-8'},
-    }).then((result) => {
+    }).then((result, status, xhr) => {
+      console.log("JSON:" + JSON.stringify(result, null, 2));
+      console.log("successful result: " + result);
+      console.log("successful status: " + xhr.status);
+      console.log("successful getAllResponseHeaders: " + xhr.getAllResponseHeaders());
+      console.log("successful responseURL:" + xhr.responseURL);
+      console.log("successful responseText:" + xhr.responseText);
+      console.log("successful responseType:" + xhr.responseType);
       if (typeof result == 'string') {
         // Pass 'result' onto normalizeResponse so it can trigger the 'shib302' thing
         throw new Error('shib302');
       }
       return this._parse_elasticsearch_result(result, info);
-    }).catch(function() {
+    }).catch(function(xhr, status, error) {
+      console.log("error:" + error);
+      console.log("error status:" + xhr.status);
+      console.log("error responseURL:" + xhr.responseURL);
+      console.log("error responseText:" + xhr.responseText);
+      console.log("error responseType:" + xhr.responseType);
+      console.log("successful getAllResponseHeaders: " + xhr.getAllResponseHeaders());
       // Pass 'result' onto normalizeResponse so it can trigger the 'shib302' thing
       throw new Error('shib302');
     });

--- a/app/adapters/fedora-jsonld.js
+++ b/app/adapters/fedora-jsonld.js
@@ -108,14 +108,19 @@ export default DS.Adapter.extend({
       headers: {'Content-Type': 'application/ld+json; charset=utf-8'},
     }).then((resp, status, xhr) => {
       // Return JSON-LD object with @id for serializer.normalizeResponse.
-
       let id = xhr.getResponseHeader('Location');
       data['@id'] = id;
-
+      if (id == null) {
+        // Pass 'result' onto normalizeResponse so it can trigger the 'shib302' thing
+        throw new Error('shib302');
+      }
       return data;
+    }).catch(function(error) {
+      // Pass 'result' onto normalizeResponse so it can trigger the 'shib302' thing
+      throw new Error('shib302');
     });
   },
-
+  
   /**
     Called by the store when an existing record is saved
     via the `save` method on a model record instance. The Fedora container representing
@@ -309,7 +314,7 @@ export default DS.Adapter.extend({
       data: JSON.stringify(data),
       headers: {'Content-Type': 'application/json; charset=utf-8'},
     }).then((result) => {
-      if (typeof result === 'string') {
+      if (typeof result == 'string') {
         // Pass 'result' onto normalizeResponse so it can trigger the 'shib302' thing
         throw new Error('shib302');
       }

--- a/app/adapters/fedora-jsonld.js
+++ b/app/adapters/fedora-jsonld.js
@@ -115,7 +115,7 @@ export default DS.Adapter.extend({
         throw new Error('shib302');
       }
       return data;
-    }).catch(function(error) {
+    }).catch(function() {
       // Pass 'result' onto normalizeResponse so it can trigger the 'shib302' thing
       throw new Error('shib302');
     });
@@ -319,7 +319,7 @@ export default DS.Adapter.extend({
         throw new Error('shib302');
       }
       return this._parse_elasticsearch_result(result, info);
-    }).catch(function(error) {
+    }).catch(function() {
       // Pass 'result' onto normalizeResponse so it can trigger the 'shib302' thing
       throw new Error('shib302');
     });

--- a/app/adapters/fedora-jsonld.js
+++ b/app/adapters/fedora-jsonld.js
@@ -314,6 +314,9 @@ export default DS.Adapter.extend({
         throw new Error('shib302');
       }
       return this._parse_elasticsearch_result(result, info);
+    }).catch(function(error) {
+      // Pass 'result' onto normalizeResponse so it can trigger the 'shib302' thing
+      throw new Error('shib302');
     });
   },
 


### PR DESCRIPTION
This extends the temporary fix of #22. The original patch caused the page to reload when a string (html) was returned from the Elasticsearch query instead of JSON, indicating a Shibboleth timeout. This new patch does the following:
- if an error is caught while querying Elasticsearch, this triggers the reload. This was added because when InCommon is used on the production site, rather than returning HTML it throws an exception due to the JS not being allowed to POST to the InCommon domain. 
- implements a similar change to what was done for Elasticsearch queries on the Fedora create method. in this instance, it assumes a Shib 302 if the create returns a null `id` or throws an error.  This is to resolve a problem where if your session times out during the submission workflow, it hangs indefinitely on the "uploading files" spinner.

### Caveats:
- With this fix, if the user times out after the Grant selection step of the submission it will not go to the login screen until you hit Submit. This is because there is no communication with Fedora or Elasticsearch until the end of the Submission. When you log back in you will have to redo the Submission 
- With this fix, _any_ error on Elasticsearch or Fedora create could result in a recurring page reload. If this happens without a timeout it indicates either a bug in the request, or that one of the services is unavailable.
- Issue #20 still very much needs to be addressed, but may actually belong in `pass-ember` issues. For example, it may be better to add some JS that detects a timeout as part of every page (or what the user would perceive to be a page!) We should probably reopen https://github.com/OA-PASS/pass-ember/issues/345

### To test:
* Clean out old docker images
* Shorten timeout to 1 minute by getting latest `pass-docker`, then navigating to  `pass-docker/sp/etc-shibboleth/shibboleth2.xml` and changing the following`<Sessions lifetime="60" timeout="60" relayState="ss:mem" checkAddress="false" handlerSSL="false" cookieProps="https">` 
* Go into `docker-compose.yml` and remove the `@sha...` extension for `sp`.
* Also in `docker-compose.yml` and `.env`, point to this commit which includes the modified adapter: https://github.com/karenhanson/pass-ember/commit/a98d817ebb044c2b533f16c5cb1203f491aa8c35
* Do `docker-compose build sp`
* Finally, `docker-compose up`
* Log in to pass, wait 1 minute and then attempt to navigate to a different page.