### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-fedora-adapter",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "description": "Adapter for the Fedora repository.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
* Bump major version because of now NPM. By default, NPM will often add dependencies in a fuzzy way, adding a `^` or `~` to the version number. This allows NPM to automatically install new minor or bugfix versions. 

This version updates Ember framework versions:

* ember-data: 3.12.3
* ember-source: 3.15
* ember-cli: 3.15.2
